### PR TITLE
fix: added dynamic globalName

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -7,6 +7,10 @@ module.exports = function (moduleOptions) {
   const isNuxtVersion2 = this.options.build.transpile
   // Fetch `apollo` option from `nuxt.config.js`
   const options = this.options.apollo || moduleOptions
+
+  // nuxtjs.org/api/configuration-global-name
+  options.globalName = this.options.globalName || 'nuxt'
+
   // Check network interfaces valid definition
   if (!options.clientConfigs) throw new Error('[Apollo module] No clientConfigs found in apollo configuration')
 

--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -54,7 +54,8 @@ export default (ctx, inject) => {
         : new InMemoryCache(<%= key %>ClientConfig.inMemoryCacheOptions ? <%= key %>ClientConfig.inMemoryCacheOptions: undefined)
 
       if (!process.server) {
-        <%= key %>Cache.restore(window.__NUXT__ ? window.__NUXT__.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
+        const nuxtWindow = window[`__<%= options.globalName.toUpperCase() %>__`]
+        <%= key %>Cache.restore(nuxtWindow ? nuxtWindow.apollo.<%= key === 'default' ? 'defaultClient' : key %> : null)
       }
 
       if (!<%= key %>ClientConfig.getAuth) {

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -2,6 +2,7 @@ const { resolve } = require('path')
 require('dotenv').config()
 
 module.exports = {
+  globalName: 'uniquename',
   rootDir: resolve(__dirname, '../..'),
   srcDir: __dirname,
   dev: false,


### PR DESCRIPTION
This PR adds support for custom globalName inside `nuxt.config`.

By default, the globalName is `nuxt`, which is being converted to: `__nuxt` and `__NUXT__`.

However, in my case, I chose a custom globalName (https://nuxtjs.org/api/configuration-global-name), which broke the apollo cache as `window.__CUSTOMNAME__.apollo` wasn't checked (only `window.__NUXT__.apollo`).

This resulted in `Mismatching childNodes vs. VNodes` errors. (#278)