### PR TITLE
feat: apollo-client-upload support

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -16,7 +16,8 @@ export default defineNuxtConfig({
     authHeader: 'Authorization',
     tokenStorage: 'cookie',
     proxyCookies: true,
-    clients: {}
+    clients: {},
+    useApolloUploadLink: true
   }
 })
 ```
@@ -76,7 +77,8 @@ export default defineNuxtConfig({
         tokenName: 'apollo:<client-name>.token',
         tokenStorage: 'cookie',
         authType: 'Bearer',
-        authHeader: 'Authorization'
+        authHeader: 'Authorization',
+        useApolloUploadLink: true
       },
       other: './apollo/other.ts'
     }
@@ -100,7 +102,8 @@ export default defineApolloClient({
   tokenName: 'apollo:<client-name>.token',
   tokenStorage: 'cookie',
   authType: 'Bearer',
-  authHeader: 'Authorization'
+  authHeader: 'Authorization',
+  useApolloUploadLink: true
 })
 ```
 ::
@@ -166,3 +169,10 @@ Specify the Authentication scheme.
   - Default: `Authorization`
 
 Name of the Authentication token header.
+
+- ### `useApolloUploadLink`
+
+  - Default: `true`
+
+Specify if the client should use `apollo-upload-client` for file uploads. This is required for file uploads.
+

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@rollup/plugin-graphql": "^2.0.5",
     "@vue/apollo-composable": "^4.2.2",
     "@vue/apollo-option": "^4.2.2",
+    "apollo-upload-client": "^18.0.1",
     "defu": "^6.1.4",
     "destr": "^2.0.5",
     "graphql": "^16.11.0",

--- a/playground/apollo/default.ts
+++ b/playground/apollo/default.ts
@@ -27,5 +27,8 @@ export default defineApolloClient({
 
   // Specify if the client should solely use WebSocket.
   // requires `wsEndpoint`.
-  websocketsOnly: false
+  websocketsOnly: false,
+
+  // Specify if the client should use `apollo-upload-client` for file uploads.
+  useApolloUploadLink: true
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vue/apollo-option':
         specifier: ^4.2.2
         version: 4.2.2(@apollo/client@3.13.9(graphql-ws@6.0.6(crossws@0.3.5)(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0))(vue@3.5.18(typescript@5.8.3))
+      apollo-upload-client:
+        specifier: ^18.0.1
+        version: 18.0.1(@apollo/client@3.13.9(graphql-ws@6.0.6(crossws@0.3.5)(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0))(graphql@16.11.0)
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -2551,6 +2554,13 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apollo-upload-client@18.0.1:
+    resolution: {integrity: sha512-OQvZg1rK05VNI79D658FUmMdoI2oB/KJKb6QGMa2Si25QXOaAvLMBFUEwJct7wf+19U8vk9ILhidBOU1ZWv6QA==}
+    engines: {node: ^18.15.0 || >=20.4.0}
+    peerDependencies:
+      '@apollo/client': ^3.8.0
+      graphql: 14 - 16
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
@@ -3581,6 +3591,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extract-files@13.0.0:
+    resolution: {integrity: sha512-FXD+2Tsr8Iqtm3QZy1Zmwscca7Jx3mMC5Crr+sEP1I303Jy1CYMuYCm7hRTplFNg3XdUavErkxnTzpaqdSoi6g==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -9511,6 +9525,12 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apollo-upload-client@18.0.1(@apollo/client@3.13.9(graphql-ws@6.0.6(crossws@0.3.5)(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0))(graphql@16.11.0):
+    dependencies:
+      '@apollo/client': 3.13.9(graphql-ws@6.0.6(crossws@0.3.5)(graphql@16.11.0)(ws@8.18.3))(graphql@16.11.0)
+      extract-files: 13.0.0
+      graphql: 16.11.0
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.4.5
@@ -10687,6 +10707,10 @@ snapshots:
   exsolve@1.0.7: {}
 
   extend@3.0.2: {}
+
+  extract-files@13.0.0:
+    dependencies:
+      is-plain-obj: 4.1.0
 
   extract-zip@2.0.1:
     dependencies:

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,7 +39,8 @@ export default defineNuxtModule<ModuleOptions>({
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax'
     },
-    clientAwareness: false
+    clientAwareness: false,
+    useApolloUploadLink: true
   },
   async setup(options, nuxt) {
     if (!options.clients || !Object.keys(options.clients).length) {
@@ -84,6 +85,7 @@ export default defineNuxtModule<ModuleOptions>({
         v.authHeader = v?.authHeader || options.authHeader
         v.tokenName = v?.tokenName || `apollo:${k}.token`
         v.tokenStorage = v?.tokenStorage || options.tokenStorage
+        v.useApolloUploadLink = v?.useApolloUploadLink || options.useApolloUploadLink
         if (v.cookieAttributes) {
           v.cookieAttributes = defu(v?.cookieAttributes, options.cookieAttributes)
         }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -4,6 +4,7 @@ import { getMainDefinition } from '@apollo/client/utilities'
 import { createApolloProvider } from '@vue/apollo-option'
 import { ApolloClients, provideApolloClients } from '@vue/apollo-composable'
 import { ApolloClient, ApolloLink, createHttpLink, InMemoryCache, split } from '@apollo/client/core'
+import uploadHttpLink from 'apollo-upload-client/createUploadLink.mjs'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { setContext } from '@apollo/client/link/context'
 import type { ClientConfig, ErrorResponse } from '../types'
@@ -73,11 +74,14 @@ export default defineNuxtPlugin((nuxtApp) => {
       }
     })
 
-    const httpLink = authLink.concat(createHttpLink({
+    const httpLinkOptions = {
       ...(clientConfig?.httpLinkOptions && clientConfig.httpLinkOptions),
       uri: (import.meta.client && clientConfig.browserHttpEndpoint) || clientConfig.httpEndpoint,
       headers: { ...(clientConfig?.httpLinkOptions?.headers || {}) }
-    }))
+    }
+
+    // Apollo Http Client
+    const httpLink = clientConfig.useApolloUploadLink ? authLink.concat(uploadHttpLink(httpLinkOptions)) : authLink.concat(createHttpLink(httpLinkOptions))
 
     let wsLink: GraphQLWsLink | null = null
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -101,6 +101,13 @@ export type ClientConfig = {
    * Configuration for the auth cookie.
    */
   cookieAttributes?: CookieAttributes
+
+  /**
+   * Use 'apollo-upload-client' for file uploads, instead of the standard apollo HttpLink.
+   * @type {boolean}
+   * @default true
+   */
+  useApolloUploadLink?: boolean
 }
 
 export interface NuxtApolloConfig<T = false> {
@@ -165,4 +172,11 @@ export interface NuxtApolloConfig<T = false> {
    * @default false
    */
   clientAwareness?: boolean
+
+  /**
+   * Use 'apollo-upload-client' for file uploads, instead of the standard apollo HttpLink.
+   * @type {boolean}
+   * @default true
+   */
+  useApolloUploadLink?: boolean
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt-modules/apollo/issues/553

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Nuxt Apollo module currently does not support file or `Blob` uploads when using `useMutation`, forcing developers to rely on custom workarounds or abandon the module.

This PR adds first-class support for file uploads by integrating apollo-upload-client and updating the Apollo client plugin to use an upload-enabled link by default.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

### What’s included

* Adds file and `Blob` upload support via `apollo-upload-client`
* Uses the upload link as the default `httpLink`
* Introduces a `useApolloUploadLink` option:

  * `true` (default): enables file uploads
  * `false`: falls back to the native `httpLink`

This preserves backward compatibility while giving users full control.

### Why this change is needed

Without this support, developers must:
* Create custom Apollo client setups just to enable uploads(my situation and many of developers), or
* Stop using the Nuxt Apollo module altogether

This PR removes that friction and provides an out-of-the-box solution that aligns with common GraphQL use cases.

###  Version compatibility

This PR uses `apollo-upload-client@v18`, which is compatible with the current dependency stack.

I have also prepared a separate branch using `v19`. It is available here:
[https://github.com/Anumide/nuxt-apollo/tree/feat/v19-apollo-client-upload](https://github.com/Anumide/nuxt-apollo/tree/feat/v19-apollo-client-upload)

Supporting v19 requires dependency upgrades, which are already being addressed in related PRs:

* [https://github.com/nuxt-modules/apollo/pull/656](https://github.com/nuxt-modules/apollo/pull/656)
* [https://github.com/nuxt-modules/apollo/pull/666](https://github.com/nuxt-modules/apollo/pull/666)
* [https://github.com/nuxt-modules/apollo/pull/660](https://github.com/nuxt-modules/apollo/pull/660)
* [https://github.com/nuxt-modules/apollo/pull/659](https://github.com/nuxt-modules/apollo/pull/659)

I’m happy to follow up with an updated PR once those changes land.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
