### PR TITLE
fix(nuxt): support Nuxt 5

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
   },
 
   vite: {
-    plugins: [GraphQLPlugin()]
+    plugins: [Promise.resolve([GraphQLPlugin()])]
   },
 
   apollo: {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,5 @@
+import GraphQLPlugin from '@rollup/plugin-graphql'
+
 export default defineNuxtConfig({
 
   modules: ['@nuxt/ui', '@nuxtjs/apollo'],
@@ -6,6 +8,10 @@ export default defineNuxtConfig({
   colorMode: {
     preference: 'dark',
     storageKey: 'na-color-scheme'
+  },
+
+  vite: {
+    plugins: [GraphQLPlugin()]
   },
 
   apollo: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,6 +12,16 @@ export type { ClientConfig, ErrorResponse }
 
 const logger = useLogger(name)
 
+async function hasGraphQLPlugin(options: PluginOption[]): Promise<boolean> {
+  for (const option of options) {
+    const plugin = await option
+    if (Array.isArray(plugin) ? await hasGraphQLPlugin(plugin) : plugin && plugin.name === 'graphql') {
+      return true
+    }
+  }
+  return false
+}
+
 async function readConfigFile(path: string): Promise<ClientConfig> {
   const jiti = createJiti(import.meta.url)
   return await jiti.import(path, { default: true })
@@ -161,13 +171,13 @@ export default defineNuxtModule<ModuleOptions>({
 
     const graphqlPlugin = GraphQLPlugin() as PluginOption
 
-    nuxt.hook('vite:extendConfig', (config) => {
+    nuxt.hook('vite:extendConfig', async (config) => {
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.exclude = config.optimizeDeps.exclude || []
       config.optimizeDeps.exclude.push('@vue/apollo-composable')
 
       config.plugins = config.plugins || []
-      if (!config.plugins.some(plugin => plugin && typeof plugin === 'object' && 'name' in plugin && plugin.name === 'graphql')) {
+      if (!await hasGraphQLPlugin(config.plugins)) {
         config.plugins.push(graphqlPlugin)
       }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,7 +25,7 @@ export default defineNuxtModule<ModuleOptions>({
     version,
     configKey: 'apollo',
     compatibility: {
-      nuxt: '^3.0.0 || ^4.0.0'
+      nuxt: '^3.0.0 || ^4.0.0 || ^5.0.0-0'
     }
   },
   defaults: {
@@ -159,13 +159,17 @@ export default defineNuxtModule<ModuleOptions>({
           ].map(n => ({ name: n, from: '@vue/apollo-composable' })))
     ])
 
+    const graphqlPlugin = GraphQLPlugin() as PluginOption
+
     nuxt.hook('vite:extendConfig', (config) => {
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.exclude = config.optimizeDeps.exclude || []
       config.optimizeDeps.exclude.push('@vue/apollo-composable')
 
       config.plugins = config.plugins || []
-      config.plugins.push(GraphQLPlugin() as PluginOption)
+      if (!config.plugins.includes(graphqlPlugin)) {
+        config.plugins.push(graphqlPlugin)
+      }
 
       if (!nuxt.options.dev) {
         config.define = { ...config.define, __DEV__: false }

--- a/src/module.ts
+++ b/src/module.ts
@@ -167,7 +167,7 @@ export default defineNuxtModule<ModuleOptions>({
       config.optimizeDeps.exclude.push('@vue/apollo-composable')
 
       config.plugins = config.plugins || []
-      if (!config.plugins.includes(graphqlPlugin)) {
+      if (!config.plugins.some(plugin => plugin && typeof plugin === 'object' && 'name' in plugin && plugin.name === 'graphql')) {
         config.plugins.push(graphqlPlugin)
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A — this is a compatibility fix for Nuxt 5 consumers.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This declares Nuxt 5 compatibility and makes GraphQL Vite plugin registration idempotent by plugin name.

Nuxt can extend separate client and SSR Vite configs over a shared plugin array, and another module or the consumer may already provide `@rollup/plugin-graphql`. Appending another `graphql` plugin makes the second transform parse the JavaScript emitted by the first as GraphQL. The module now reuses one plugin instance and only adds it when no `graphql` plugin is already registered.

The playground preloads the real GraphQL plugin as regression coverage. Before the name-based guard, `pnpm dev:build` fails on `playground/queries/launches.gql` with `Syntax Error: Unexpected Name "var"`; with the guard, both client and SSR builds pass.

### ✅ Checks

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm dev:build` (Nuxt 4.0.2 / Nitro 2.12.4)
- [x] Packed consumer build with `nuxt-nightly@5.0.0-29762631.396a4ae3`, `@nuxt/kit-nightly@5.0.0-29762631.396a4ae3`, Nitro `3.0.260610-beta`, Vite 8.2.1, a real `.gql` import, and an existing `graphql` plugin

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
